### PR TITLE
Fix unsafe_to_exception

### DIFF
--- a/src/Error.re
+++ b/src/Error.re
@@ -10,7 +10,7 @@ let unsafe_from_exception : exn => Js.Exn.t = exception_ =>
     | _ => raise(Not_found)
     };
 
-let unsaafe_to_exception : Js.Exn.t => exn = error =>
+let unsafe_to_exception : Js.Exn.t => exn = error =>
   try ({
     throw(error);
     Not_found;

--- a/test/Test_Error.re
+++ b/test/Test_Error.re
@@ -24,7 +24,7 @@ describe("unsafe_from_exception and unsafe_to_exception", () => {
 
     expect(Js.Re.test(stack_trace(foobar), expected_stack_trace)).to_be(true);
     expect(
-      foobar |> Error.unsaafe_to_exception |> Error.unsafe_from_exception |> stack_trace
+      foobar |> Error.unsafe_to_exception |> Error.unsafe_from_exception |> stack_trace
     ).to_be(stack_trace(foobar));
   });
 });


### PR DESCRIPTION
This pull-request fixes a typo in the source and the test, renaming `unsaafe_to_exception` to `unsafe_to_exception`.